### PR TITLE
Send auth token on API requests instead of cookies

### DIFF
--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -26,7 +26,7 @@ const AuthContext = createContext<AuthCtx | null>(null);
 
 // ---- replace / adjust to your API ----
 async function getMeta() {
-  const { data } = await api.get("/meta", { requireAuth: true });
+  const { data } = await api.get("/meta");
   return data as Meta;
 }
 
@@ -65,7 +65,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     const rt = refreshRef.current ?? tokenStore.readPersisted().refresh;
     if (!rt) throw new Error("No refresh token");
     // Most APIs accept the refresh in body; adapt if your API expects headers
-    const { data } = await api.post("/auth/refresh", { refresh_token: rt }); // public call
+    const { data } = await api.post(
+      "/auth/refresh",
+      { refresh_token: rt },
+      { skipAuth: true }
+    ); // public call
 
     // support snakeCase or camelCase
     const newAccess: string = data.access_token ?? data.accessToken;
@@ -78,7 +82,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   };
 
   const login: AuthCtx["login"] = async (email, password, remember = false) => {
-    const { data } = await api.post("/auth/login", { email, password }); // public call
+    const { data } = await api.post(
+      "/auth/login",
+      { email, password },
+      { skipAuth: true }
+    ); // public call
 
     const a: string = data.access_token ?? data.accessToken;
     const r: string = data.refresh_token ?? data.refreshToken;
@@ -98,11 +106,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const logout = async () => {
     const rt = refreshRef.current ?? tokenStore.getRefresh();
     try {
-      await api.post(
-        "/auth/logout",
-        { refreshToken: rt },
-        { requireAuth: true }
-      );
+      await api.post("/auth/logout", { refreshToken: rt });
     } catch {
       /* ignore */
     }
@@ -186,13 +190,13 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   // ---- Axios interceptors ----
   useEffect(() => {
-    // REQUEST: attach access token only when explicitly requested
+    // REQUEST: attach access token unless skipped
     const apiHost = api.defaults.baseURL
       ? new URL(api.defaults.baseURL).host
       : null;
 
     const reqId = api.interceptors.request.use((config) => {
-      if (config.requireAuth && accessRef.current) {
+      if (!config.skipAuth && accessRef.current) {
         // host safety: never attach to other domains
         const abs = config.url
           ? new URL(config.url, api.defaults.baseURL || window.location.origin)
@@ -201,7 +205,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
         config.headers = config.headers ?? {};
         if (!config.headers.Authorization) {
-      (config.headers as Record<string, unknown>).Authorization = `Bearer ${accessRef.current}`;
+          (config.headers as Record<string, unknown>).Authorization = `Bearer ${accessRef.current}`;
         }
       }
       return config;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -2,5 +2,4 @@ import axios from "axios";
 
 export const api = axios.create({
   baseURL: import.meta.env.VITE_API_URL ?? "http://localhost:4000",
-  withCredentials: true,
 });

--- a/src/pages/apps/Apps.tsx
+++ b/src/pages/apps/Apps.tsx
@@ -21,7 +21,7 @@ function Apps() {
   useEffect(() => {
     (async () => {
       try {
-        const { data } = await api.get("/projects", { requireAuth: true });
+        const { data } = await api.get("/projects");
         if (Array.isArray(data) && data.length > 0) {
           setProjectId(data[0].id);
         }
@@ -37,7 +37,6 @@ function Apps() {
       try {
         const { data } = await api.get("/apps", {
           params: { projectId },
-          requireAuth: true,
         });
         setApps(Array.isArray(data) ? data : []);
       } catch {
@@ -50,14 +49,9 @@ function Apps() {
     e.preventDefault();
     if (!projectId) return;
     try {
-      await api.post(
-        "/apps",
-        { projectId, name, description },
-        { requireAuth: true }
-      );
+      await api.post("/apps", { projectId, name, description });
       const { data } = await api.get("/apps", {
         params: { projectId },
-        requireAuth: true,
       });
       setApps(Array.isArray(data) ? data : []);
       setOpen(false);

--- a/src/pages/projects/Projects.tsx
+++ b/src/pages/projects/Projects.tsx
@@ -15,7 +15,7 @@ function Projects() {
   useEffect(() => {
     (async () => {
       try {
-        const { data } = await api.get("/projects", { requireAuth: true });
+        const { data } = await api.get("/projects");
         if (Array.isArray(data) && data.length > 0) {
           navigate("/apps", { replace: true });
         } else {
@@ -30,11 +30,7 @@ function Projects() {
   const createProject = async (e: FormEvent) => {
     e.preventDefault();
     try {
-      await api.post(
-        "/projects",
-        { name, description, createRepo: false },
-        { requireAuth: true }
-      );
+      await api.post("/projects", { name, description, createRepo: false });
       navigate("/apps", { replace: true });
     } catch {
       /* handle error - omitted */

--- a/src/types/axios.d.ts
+++ b/src/types/axios.d.ts
@@ -2,6 +2,6 @@ import "axios";
 declare module "axios" {
   export interface AxiosRequestConfig {
     _retry?: boolean;
-    requireAuth?: boolean;
+    skipAuth?: boolean;
   }
 }


### PR DESCRIPTION
## Summary
- Remove cookie-based credentials from Axios instance
- Automatically attach Bearer tokens to requests and add `skipAuth` option
- Drop `requireAuth` flag from API calls

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c1a94284f4832489baeb34701187a6