### PR TITLE
Simplify token storage and ensure bearer token in requests

### DIFF
--- a/src/auth/token.ts
+++ b/src/auth/token.ts
@@ -12,10 +12,6 @@ export function getExpMs(token: string | null): number | null {
   }
 }
 
-// In-memory (safer against XSS than localStorage)
-let inMemAccess: string | null = null;
-let inMemRefresh: string | null = null;
-
 const LS = {
   access: "access_token",
   refresh: "refresh_token",
@@ -23,24 +19,11 @@ const LS = {
 
 export const tokenStore = {
   // getters
-  getAccess: () => {
-    if (inMemAccess) return inMemAccess;
-    const token = localStorage.getItem(LS.access);
-    inMemAccess = token;
-    return token;
-  },
-  getRefresh: () => {
-    if (inMemRefresh) return inMemRefresh;
-    const token = localStorage.getItem(LS.refresh);
-    inMemRefresh = token;
-    return token;
-  },
+  getAccess: () => localStorage.getItem(LS.access),
+  getRefresh: () => localStorage.getItem(LS.refresh),
 
   // set both and persist in localStorage
   setBoth: (access: string | null, refresh: string | null) => {
-    inMemAccess = access;
-    inMemRefresh = refresh;
-
     if (access) localStorage.setItem(LS.access, access);
     else localStorage.removeItem(LS.access);
     if (refresh) localStorage.setItem(LS.refresh, refresh);
@@ -49,14 +32,12 @@ export const tokenStore = {
 
   // update just access (e.g., on refresh)
   setAccess: (access: string | null) => {
-    inMemAccess = access;
     if (access) localStorage.setItem(LS.access, access);
     else localStorage.removeItem(LS.access);
   },
 
   // update just refresh (e.g., on rotation)
   setRefresh: (refresh: string | null) => {
-    inMemRefresh = refresh;
     if (refresh) localStorage.setItem(LS.refresh, refresh);
     else localStorage.removeItem(LS.refresh);
   },

--- a/src/components/login-form.tsx
+++ b/src/components/login-form.tsx
@@ -18,7 +18,7 @@ export function LoginForm({ className }: React.ComponentProps<"div">) {
     e.preventDefault();
     setError(null);
     try {
-      await login(email, password, remember);
+      await login(email, password);
       navigate("/", { replace: true });
     } catch (err: unknown) {
       const apiErr = err as { response?: { data?: { message?: string } } };

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -18,7 +18,7 @@ type AuthCtx = {
   meta: Meta;
   isAuthenticated: boolean;
   loading: boolean;
-  login: (email: string, password: string, remember?: boolean) => Promise<void>;
+  login: (email: string, password: string) => Promise<void>;
   logout: () => Promise<void> | void;
 };
 
@@ -80,7 +80,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     return newAccess;
   };
 
-  const login: AuthCtx["login"] = async (email, password, _remember = false) => {
+  const login: AuthCtx["login"] = async (email, password) => {
     const { data } = await api.post(
       "/auth/login",
       { email, password },

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -11,7 +11,7 @@ export const api = axios.create({
 api.interceptors.request.use((config) => {
   if (!config.skipAuth) {
     const token = tokenStore.getAccess();
-    if (token && !config.headers?.Authorization) {
+    if (token) {
       config.headers = config.headers ?? {};
       (config.headers as Record<string, unknown>).Authorization = `Bearer ${token}`;
     }


### PR DESCRIPTION
## Summary
- Store access and refresh tokens directly in localStorage and expose simple helpers
- Always attach bearer tokens from storage on API requests
- Remove unused remember flag from login flow

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c1b2f2deb883249442f0e7885f3c54