### PR TITLE
Fix get projects API response

### DIFF
--- a/src/lib/projects.ts
+++ b/src/lib/projects.ts
@@ -1,0 +1,7 @@
+import { api } from "./api";
+import type { GetProjectsResponse, Project } from "@/types/project";
+
+export async function getProjects(): Promise<Project[]> {
+  const { data } = await api.get<GetProjectsResponse>("/projects");
+  return Array.isArray(data?.data) ? data.data : [];
+}

--- a/src/pages/apps/Apps.tsx
+++ b/src/pages/apps/Apps.tsx
@@ -1,18 +1,14 @@
 import { useEffect, useState, type FormEvent } from "react";
 import { api } from "@/lib/api";
+import { getProjects } from "@/lib/projects";
+import type { App } from "@/types/app";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 
-interface AppEntity {
-  id: number;
-  name: string;
-  description?: string;
-}
-
 function Apps() {
-  const [apps, setApps] = useState<AppEntity[]>([]);
+  const [apps, setApps] = useState<App[]>([]);
   const [projectId, setProjectId] = useState<number | null>(null);
   const [open, setOpen] = useState(false);
   const [name, setName] = useState("");
@@ -21,9 +17,9 @@ function Apps() {
   useEffect(() => {
     (async () => {
       try {
-        const { data } = await api.get("/projects");
-        if (Array.isArray(data) && data.length > 0) {
-          setProjectId(data[0].id);
+        const projects = await getProjects();
+        if (projects.length > 0) {
+          setProjectId(projects[0].project_id);
         }
       } catch {
         /* ignore */

--- a/src/pages/projects/Projects.tsx
+++ b/src/pages/projects/Projects.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, type FormEvent } from "react";
 import { useNavigate } from "react-router-dom";
 import { api } from "@/lib/api";
+import { getProjects } from "@/lib/projects";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -15,8 +16,8 @@ function Projects() {
   useEffect(() => {
     (async () => {
       try {
-        const { data } = await api.get("/projects");
-        if (Array.isArray(data) && data.length > 0) {
+        const projects = await getProjects();
+        if (projects.length > 0) {
           navigate("/apps", { replace: true });
         } else {
           setOpen(true);

--- a/src/types/app.ts
+++ b/src/types/app.ts
@@ -1,0 +1,5 @@
+export interface App {
+  id: number;
+  name: string;
+  description?: string;
+}

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -1,0 +1,24 @@
+export interface Company {
+  company_id: number;
+  name: string;
+  description: string;
+  user_limit: number;
+  app_limit: number;
+  status: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface Project {
+  project_id: number;
+  company: Company;
+  name: string;
+  repo_url: string;
+  git_pat_encrypted: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface GetProjectsResponse {
+  data: Project[];
+}


### PR DESCRIPTION
## Summary
- handle nested `data` field in getProjects API
- define app and project types in dedicated folder
- reuse new `getProjects` helper across pages

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1b6534f3083248e9f3e1ec4954ac6