### PR TITLE
Handle nested apps response

### DIFF
--- a/src/pages/apps/Apps.tsx
+++ b/src/pages/apps/Apps.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, type FormEvent } from "react";
 import { api } from "@/lib/api";
 import { getProjects } from "@/lib/projects";
-import type { App } from "@/types/app";
+import type { App, GetAppsResponse } from "@/types/app";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -31,10 +31,10 @@ function Apps() {
     if (!projectId) return;
     (async () => {
       try {
-        const { data } = await api.get("/apps", {
+        const { data } = await api.get<GetAppsResponse>("/apps", {
           params: { projectId },
         });
-        setApps(Array.isArray(data) ? data : []);
+        setApps(Array.isArray(data?.data) ? data.data : []);
       } catch {
         setApps([]);
       }
@@ -46,10 +46,10 @@ function Apps() {
     if (!projectId) return;
     try {
       await api.post("/apps", { projectId, name, description });
-      const { data } = await api.get("/apps", {
+      const { data } = await api.get<GetAppsResponse>("/apps", {
         params: { projectId },
       });
-      setApps(Array.isArray(data) ? data : []);
+      setApps(Array.isArray(data?.data) ? data.data : []);
       setOpen(false);
       setName("");
       setDescription("");
@@ -65,7 +65,7 @@ function Apps() {
       ) : (
         <ul className="space-y-2">
           {apps.map((a) => (
-            <li key={a.id} className="border p-2">
+            <li key={a.app_id} className="border p-2">
               {a.name}
             </li>
           ))}

--- a/src/types/app.ts
+++ b/src/types/app.ts
@@ -1,5 +1,12 @@
+import type { Project } from "./project";
+
 export interface App {
-  id: number;
+  app_id: number;
+  project: Project;
   name: string;
   description?: string;
+}
+
+export interface GetAppsResponse {
+  data: App[];
 }


### PR DESCRIPTION
## Summary
- adapt apps page to parse nested `data` property from `/apps` endpoint
- align `App` type with server fields

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1b7d51a1c83248c0951f06b7dc68e