### PR TITLE
Add tree view and navigation for app details

### DIFF
--- a/src/pages/apps/AppDetail.tsx
+++ b/src/pages/apps/AppDetail.tsx
@@ -1,5 +1,57 @@
+import { useParams } from "react-router-dom";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+
+interface TreeNode {
+  name: string;
+  type: "folder" | "file";
+  children?: TreeNode[];
+}
+
+function Tree({ nodes }: { nodes: TreeNode[] }) {
+  return (
+    <ul className="ml-4">
+      {nodes.map((node, idx) => (
+        <li key={idx}>
+          <div>
+            {node.type === "folder" ? "📁" : "📄"} {node.name}
+          </div>
+          {node.children && node.children.length > 0 && (
+            <Tree nodes={node.children} />
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
 function AppDetail() {
-  return <div>App Detail</div>;
+  const { id } = useParams<{ id: string }>();
+  const [tree, setTree] = useState<TreeNode[]>([]);
+
+  const addFolder = () => {
+    const name = window.prompt("Folder name");
+    if (!name) return;
+    setTree([...tree, { name, type: "folder", children: [] }]);
+  };
+
+  const addFile = () => {
+    const name = window.prompt("Feature file name");
+    if (!name) return;
+    setTree([...tree, { name, type: "file" }]);
+  };
+
+  return (
+    <div className="p-4">
+      <h1 className="mb-4 text-xl">App {id}</h1>
+      <div className="mb-4 flex gap-2">
+        <Button onClick={addFolder}>Add Folder</Button>
+        <Button onClick={addFile}>Add Feature File</Button>
+      </div>
+      {tree.length === 0 ? <p>No files yet</p> : <Tree nodes={tree} />}
+    </div>
+  );
 }
 
 export default AppDetail;
+

--- a/src/pages/apps/Apps.tsx
+++ b/src/pages/apps/Apps.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, type FormEvent } from "react";
+import { Link } from "react-router-dom";
 import { api } from "@/lib/api";
 import { getProjects } from "@/lib/projects";
 import type { App, GetAppsResponse } from "@/types/app";
@@ -66,7 +67,7 @@ function Apps() {
         <ul className="space-y-2">
           {apps.map((a) => (
             <li key={a.app_id} className="border p-2">
-              {a.name}
+              <Link to={`/app/${a.app_id}`}>{a.name}</Link>
             </li>
           ))}
         </ul>


### PR DESCRIPTION
## Summary
- Link each app to a detail page route `/app/:id`
- Implement app detail page with interactive file tree and buttons to add folders or feature files

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1b9333aac8324b78f95e1d1c9d3f5